### PR TITLE
5 move access token to a new stitch block

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@AlessandroLollo

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,1 @@
+::: prefect_stitch.stitch_client

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,1 @@
+::: prefect_stitch.credentials

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,5 +48,7 @@ plugins:
 
 nav:
     - Home: index.md
+    - Credentials: credentials.md
+    - Client: client.md
     - Tasks: tasks.md
 

--- a/prefect_stitch/credentials.py
+++ b/prefect_stitch/credentials.py
@@ -1,0 +1,24 @@
+"""Stitch credentials block"""
+from prefect.blocks.core import Block
+from pydantic import SecretStr
+
+
+class StitchCredentials(Block):
+    """
+    Block used to manage authentication with Stitch.
+    Args:
+        access_token (SecretStr): The Access token to use to connect to Stitch.
+
+    Example:
+        Load stored Stitch credentials
+        ```python
+        from prefect_stitch.credentials import StitchCredentials
+        stitch_credentials_block = StitchCredentials.load("BLOCK_NAME")
+        ```
+    """  # noqa E501
+
+    access_token: SecretStr
+
+    _block_type_name = "Stitch Credentials"
+
+    _logo_url = "https://github.com/PrefectHQ/prefect/blob/main/docs/img/collections/stitch.png?raw=true"  # noqa

--- a/prefect_stitch/stitch_client.py
+++ b/prefect_stitch/stitch_client.py
@@ -1,5 +1,5 @@
 """
-Collection of utils to interact with Stitch APIs.
+An object that can be used to interact with Stitch APIs.
 """
 
 from typing import Dict, Optional
@@ -12,8 +12,12 @@ from prefect_stitch.exceptions import StitchAPIFailureException
 
 class StitchClient:
     """
-    Class that represents a Stitch client that can be used to interact
-    with Stitch APIs.
+    Create a client that can be used to interact with Stitch APIs
+    using the provided access token to authenticate API calls.
+
+    Args:
+        credentials: access token that will be used to
+            authenticate API calls.
     """
 
     # Stitch API base url
@@ -23,14 +27,6 @@ class StitchClient:
     __STITCH_API_VERSION = "v4"
 
     def __init__(self, credentials: StitchCredentials) -> None:
-        """
-        Create a client that can be used to interact with Stitch APIs
-        using the provided access token to authenticate API calls.
-
-        Args:
-            access_token: access token that will be used to
-                authenticate API calls.
-        """
         self.credentials = credentials
 
     def __get_base_url(self) -> str:

--- a/prefect_stitch/stitch_client.py
+++ b/prefect_stitch/stitch_client.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional
 
 from requests import Session
 
+from prefect_stitch.credentials import StitchCredentials
 from prefect_stitch.exceptions import StitchAPIFailureException
 
 
@@ -21,7 +22,7 @@ class StitchClient:
     # Stitch API version
     __STITCH_API_VERSION = "v4"
 
-    def __init__(self, access_token: str) -> None:
+    def __init__(self, credentials: StitchCredentials) -> None:
         """
         Create a client that can be used to interact with Stitch APIs
         using the provided access token to authenticate API calls.
@@ -30,7 +31,7 @@ class StitchClient:
             access_token: access token that will be used to
                 authenticate API calls.
         """
-        self.access_token = access_token
+        self.credentials = credentials
 
     def __get_base_url(self) -> str:
         """
@@ -61,9 +62,10 @@ class StitchClient:
         Returns:
             Session object configured with the proper headers.
         """
+        access_token = self.credentials.access_token.get_secret_value()
         session = Session()
         session.headers = {
-            "Authorization": f"Bearer {self.access_token}",
+            "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
         }
 

--- a/prefect_stitch/tasks.py
+++ b/prefect_stitch/tasks.py
@@ -9,11 +9,12 @@ from typing import Dict
 
 from prefect import task
 
-from prefect_stitch.utils import StitchClient
+from prefect_stitch.credentials import StitchCredentials
+from prefect_stitch.stitch_client import StitchClient
 
 
 @task
-def start_replication_job(access_token: str, source_id: int) -> Dict:
+def start_replication_job(credentials: StitchCredentials, source_id: int) -> Dict:
     """
     This task starts a new Stitch replication job using the provided source.
 
@@ -25,5 +26,5 @@ def start_replication_job(access_token: str, source_id: int) -> Dict:
     Returns:
         Replication job API JSON response.
     """
-    stitch_client = StitchClient(access_token=access_token)
+    stitch_client = StitchClient(credentials=credentials)
     return stitch_client.start_replication_job(source_id=source_id)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,9 @@
+from pydantic import SecretStr
+
+from prefect_stitch.credentials import StitchCredentials
+
+
+def test_credentials_construction():
+    cred = StitchCredentials(access_token=SecretStr("foo"))
+
+    assert cred.access_token.get_secret_value() == "foo"

--- a/tests/test_stitch_client.py
+++ b/tests/test_stitch_client.py
@@ -1,0 +1,125 @@
+import pytest
+import responses
+from pydantic import SecretStr
+
+from prefect_stitch.credentials import StitchCredentials
+from prefect_stitch.exceptions import StitchAPIFailureException
+from prefect_stitch.stitch_client import StitchClient
+
+
+def test_stitch_client_construction():
+
+    client = StitchClient(credentials=StitchCredentials(access_token=SecretStr("foo")))
+
+    assert client.credentials.access_token.get_secret_value() == "foo"
+
+
+@responses.activate
+def test_start_replication_job_raises():
+
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(method=responses.POST, url=api_url, status=123)
+
+    msg_match = "There was an error while calling Stitch API"
+    with pytest.raises(StitchAPIFailureException, match=msg_match):
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        client = StitchClient(credentials=creds)
+
+        client.start_replication_job(source_id=1234)
+
+
+@responses.activate
+def test_start_replication_job_with_invalid_source_raises():
+
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(
+        method=responses.POST,
+        url=api_url,
+        status=400,
+        json={
+            "error": {
+                "type": "invalid_source",
+                "message": "Unable to locate source(1234) for client (<CLIENT_ID>)",
+            }
+        },
+    )
+
+    msg_match = "Stitch API responded with error: Unable to locate source"
+    with pytest.raises(StitchAPIFailureException, match=msg_match):
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        client = StitchClient(credentials=creds)
+
+        client.start_replication_job(source_id=1234)
+
+
+@responses.activate
+def test_start_replication_job_with_deleted_source_raises():
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(
+        method=responses.POST,
+        url=api_url,
+        status=400,
+        json={
+            "error": {"type": "invalid_source", "message": "Integration is deleted."}
+        },
+    )
+
+    msg_match = "Stitch API responded with error: Integration is deleted."
+    with pytest.raises(StitchAPIFailureException, match=msg_match):
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        client = StitchClient(credentials=creds)
+
+        client.start_replication_job(source_id=1234)
+
+
+@responses.activate
+def test_start_replication_job_already_running_raises():
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(
+        method=responses.POST,
+        url=api_url,
+        status=200,
+        json={
+            "error": {
+                "type": "already_running",
+                "message": "Did not create job for client-id",
+            }
+        },
+    )
+
+    msg_match = "Stitch API responded with error: Did not create job for client-id"
+    with pytest.raises(StitchAPIFailureException, match=msg_match):
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        client = StitchClient(credentials=creds)
+
+        client.start_replication_job(source_id=1234)
+
+
+@responses.activate
+def test_start_replication_job_check_auth_headers():
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(
+        method=responses.POST, url=api_url, status=200, json={"job_name": "foo"}
+    )
+
+    creds = StitchCredentials(access_token=SecretStr("foo"))
+    client = StitchClient(credentials=creds)
+
+    client.start_replication_job(source_id=1234)
+
+    assert responses.calls[0].request.headers["Authorization"] == "Bearer foo"
+
+
+@responses.activate
+def test_start_replication_job_success():
+    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
+    responses.add(
+        method=responses.POST, url=api_url, status=200, json={"job_name": "foo"}
+    )
+
+    creds = StitchCredentials(access_token=SecretStr("foo"))
+    client = StitchClient(credentials=creds)
+
+    result = client.start_replication_job(source_id=1234)
+
+    assert result == {"job_name": "foo"}

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,141 +1,34 @@
 import pytest
 import responses
 from prefect import flow
+from pydantic import SecretStr
 
+from prefect_stitch.credentials import StitchCredentials
 from prefect_stitch.exceptions import StitchAPIFailureException
 from prefect_stitch.tasks import start_replication_job
-from prefect_stitch.utils import StitchClient
 
 
-def test_stitch_client_init():
-    sc = StitchClient(access_token="abc")
-
-    assert sc.access_token == "abc"
-
-
-def test_run_without_source_id_raises():
-    @flow(name="test_flow_1")
+def test_start_replication_job_fails():
+    @flow(name="failing_flow")
     def test_flow():
-        return start_replication_job(access_token="abc", source_id=None)
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        return start_replication_job(credentials=creds, source_id=1234)
 
-    msg_match = "To start a replication job, please provide the the source identifier"
-
-    with pytest.raises(StitchAPIFailureException, match=msg_match):
+    with pytest.raises(StitchAPIFailureException):
         test_flow()
 
 
 @responses.activate
-def test_run_with_not_ok_status_code_raises():
-    @flow(name="test_flow")
-    def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
-    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
-    responses.add(method=responses.POST, url=api_url, status=123)
-
-    msg_match = "There was an error while calling Stitch API"
-    with pytest.raises(StitchAPIFailureException, match=msg_match):
-
-        test_flow()
-
-
-@responses.activate
-def test_run_with_invalid_source_raises():
-    @flow(name="test_flow_2")
-    def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
-    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
-    responses.add(
-        method=responses.POST,
-        url=api_url,
-        status=400,
-        json={
-            "error": {
-                "type": "invalid_source",
-                "message": "Unable to locate source(1234) for client (<CLIENT_ID>)",
-            }
-        },
-    )
-
-    msg_match = "Stitch API responded with error: Unable to locate source"
-    with pytest.raises(StitchAPIFailureException, match=msg_match):
-        test_flow()
-
-
-@responses.activate
-def test_run_with_deleted_source_raises():
-    @flow(name="test_flow_3")
-    def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
-    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
-    responses.add(
-        method=responses.POST,
-        url=api_url,
-        status=400,
-        json={
-            "error": {"type": "invalid_source", "message": "Integration is deleted."}
-        },
-    )
-
-    msg_match = "Stitch API responded with error: Integration is deleted."
-
-    with pytest.raises(StitchAPIFailureException, match=msg_match):
-        test_flow()
-
-
-@responses.activate
-def test_run_already_running_job_raises():
-    @flow(name="test_flow_4")
-    def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
-    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
-    responses.add(
-        method=responses.POST,
-        url=api_url,
-        status=200,
-        json={
-            "error": {
-                "type": "already_running",
-                "message": "Did not create job for client-id",
-            }
-        },
-    )
-
-    msg_match = "Stitch API responded with error: Did not create job for client-id"
-
-    with pytest.raises(StitchAPIFailureException, match=msg_match):
-        test_flow()
-
-
-@responses.activate
-def test_run_with_valid_source_check_auth_headers():
-    @flow(name="test_flow_5")
-    def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
+def test_start_replication_job_succeed():
     api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
     responses.add(
         method=responses.POST, url=api_url, status=200, json={"job_name": "foo"}
     )
 
-    test_flow()
-
-    assert responses.calls[0].request.headers["Authorization"] == "Bearer abc"
-
-
-@responses.activate
-def test_run_success():
-    @flow(name="test_flow_6")
+    @flow(name="succeeding_flow")
     def test_flow():
-        return start_replication_job(access_token="abc", source_id=1234)
-
-    api_url = "https://api.stitchdata.com/v4/sources/1234/sync"
-    responses.add(
-        method=responses.POST, url=api_url, status=200, json={"job_name": "foo"}
-    )
+        creds = StitchCredentials(access_token=SecretStr("foo"))
+        return start_replication_job(credentials=creds, source_id=1234)
 
     result = test_flow()
 


### PR DESCRIPTION
## Summary

- Moved sensitive information to a dedicated Stitch Block.
- Renamed `utils` to `stitch_client` and introduced a `StitchClient` object to interact with Stitch

